### PR TITLE
In crontab model make the channel_id field optional.

### DIFF
--- a/web/slackbot/models.py
+++ b/web/slackbot/models.py
@@ -11,6 +11,7 @@ class Crontab(models.Model):
     channel_name = models.CharField(max_length=100, blank=True)
     channel_id = models.CharField(
         max_length=30,
+        blank=True,
         help_text="Slack internal channel ID, will be "
         "automatically set based on channel_name",
     )


### PR DESCRIPTION
Now you can't add new job with channel name on the UI,
because the channel id is a required field.